### PR TITLE
Add support for callback urls in verification sessions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ apply plugin: 'eclipse'
 version = '0.6.1'
 group = 'org.irmacard.api'
 
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
+
 repositories {
     mavenLocal()
     maven {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
 
-version = '0.6.0'
+version = '0.6.1'
 group = 'org.irmacard.api'
 
 repositories {

--- a/src/main/java/org/irmacard/api/common/ClientRequest.java
+++ b/src/main/java/org/irmacard/api/common/ClientRequest.java
@@ -5,6 +5,7 @@ public class ClientRequest<T> {
 	private int timeout = 0;
 	private String data;
 	private T request;
+	private String callbackUrl;
 
 	public ClientRequest() {}
 
@@ -17,6 +18,15 @@ public class ClientRequest<T> {
 		this.timeout = timeout;
 		this.request = request;
 		this.data = data;
+	}
+
+	public ClientRequest(String data, T request, int timeout, String callbackUrl) {
+		this(data, request, timeout);
+		this.callbackUrl = callbackUrl;
+	}
+
+	public String getCallbackUrl() {
+		return callbackUrl;
 	}
 
 	public int getTimeout() {


### PR DESCRIPTION
To reduce complexity at the service provider's side, it can sometimes be desired to let the `irma_api_server` call a url at the service provider's website, instead of letting the service provider 'wait' for a disclosure result on a websocket/http poll.

Besides adding support for callback url's, I also added a fix for compiling the `irma_android_cardemu` app with the latest android sdk and java 8. 